### PR TITLE
Fix mobile nav and hero doodle overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
     #top>div:last-child{min-height:auto!important;margin-top:8px;}
     .g-stack{grid-template-columns:1fr!important;}
     .g-half,[data-panel]{grid-template-columns:repeat(2,1fr)!important;}
+    .navlink{display:none!important;}
+    .hero-doodle{display:none!important;}
+    [data-nav]{padding:12px 18px!important;}
   }
 </style>
 </head>
@@ -41,10 +44,10 @@
       <span style="font-family:'Shantell Sans',cursive;font-weight:800;font-size:24px;color:#2A1E12;">ReciPics</span>
     </a>
     <div style="display:flex;align-items:center;gap:clamp(14px,2.4vw,30px);font-weight:700;font-size:16px;color:#5b4a38;">
-      <a href="#how" style="text-decoration:none;color:inherit;">How it works</a>
-      <a href="#features" style="text-decoration:none;color:inherit;">Features</a>
-      <a href="#plan" style="text-decoration:none;color:inherit;">Plan &amp; shop</a>
-      <a href="#loved" style="text-decoration:none;color:inherit;">Reviews</a>
+      <a href="#how" class="navlink" style="text-decoration:none;color:inherit;">How it works</a>
+      <a href="#features" class="navlink" style="text-decoration:none;color:inherit;">Features</a>
+      <a href="#plan" class="navlink" style="text-decoration:none;color:inherit;">Plan &amp; shop</a>
+      <a href="#loved" class="navlink" style="text-decoration:none;color:inherit;">Reviews</a>
       <a href="https://apps.apple.com/us/app/genichef-ai-meal-genius/id6740248018" style="text-decoration:none;display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,#FF8C1A,#FF7A00);color:#fff;padding:11px 22px;border-radius:999px;font-weight:800;box-shadow:0 10px 22px -8px rgba(214,103,0,.7);">Get the app</a>
     </div>
   </div>
@@ -86,7 +89,7 @@
     <div style="position:relative;display:flex;justify-content:center;align-items:center;min-height:580px;">
       <span data-par="0.05" style="position:absolute;top:24px;right:0;z-index:4;"><span style="display:block;width:104px;height:104px;border-radius:50%;overflow:hidden;border:5px solid #fff;box-shadow:0 16px 30px -12px rgba(80,50,10,.5);animation:bobR 6s ease-in-out infinite;"><img src="resources/pizza.png" style="width:100%;height:100%;object-fit:cover;"></span></span>
       <span data-par="0.09" style="position:absolute;bottom:54px;left:-8px;z-index:4;"><span style="display:block;width:112px;height:112px;border-radius:50%;overflow:hidden;border:5px solid #fff;box-shadow:0 16px 30px -12px rgba(80,50,10,.5);animation:bobS 7s ease-in-out infinite;"><img src="resources/vegitablesTable.jpeg" style="width:100%;height:100%;object-fit:cover;"></span></span>
-      <span data-par="0.04" style="position:absolute;top:-6px;left:36px;font-family:'Caveat',cursive;font-weight:700;font-size:30px;color:#3B5A00;transform:rotate(-8deg);">snap it! &#8600;</span>
+      <span data-par="0.04" class="hero-doodle" style="position:absolute;top:-6px;left:36px;font-family:'Caveat',cursive;font-weight:700;font-size:30px;color:#3B5A00;transform:rotate(-8deg);">snap it! &#8600;</span>
 
       <div data-tilt style="position:relative;z-index:3;transition:transform .25s ease;transform-style:preserve-3d;">
         <div style="position:relative;width:clamp(260px,30vw,300px);aspect-ratio:9/19.5;background:#15110c;border-radius:46px;padding:11px;box-shadow:0 40px 70px -20px rgba(214,103,0,.55),0 0 0 2px rgba(0,0,0,.06);animation:bob 8s ease-in-out infinite;">


### PR DESCRIPTION
Two real-device mobile bugs:
- **Nav** links wrapped and collided with the logo, pushing the CTA off-screen → below 760px, hide the in-page anchor links (keep logo + "Get the app"), tighten nav padding
- **Hero** "snap it!" doodle sat behind the phone image → hidden below 760px

Verified at mobile width: nav fits within viewport, no horizontal overflow, doodle no longer overlapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)